### PR TITLE
Resolved a fatal issue with Shell checking

### DIFF
--- a/HQ Trivia Master/Shell.swift
+++ b/HQ Trivia Master/Shell.swift
@@ -64,8 +64,8 @@ class Shell
         var error : [String] = []
         
         let task = Process()
-        task.launchPath = cmd
-        task.arguments = args
+        task.launchPath = "/usr/bin/env"
+        task.arguments = [cmd] + args
         
         let outpipe = Pipe()
         task.standardOutput = outpipe


### PR DESCRIPTION
For some reason, the launch path can sometimes cause a crash if the user doesn't have `Tesseract` or `ImageMagick` installed.  I couldn't replicate the issue but this will permanently resolve this issue.